### PR TITLE
Use keycloak version from pom in docker-compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - "8443:8443"
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.0.0
+    image: quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}
 
     entrypoint: /bin/bash
     command:

--- a/pom.xml
+++ b/pom.xml
@@ -157,6 +157,9 @@
                 <java.util.logging.config.file>
                   ${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
               </systemPropertyVariables>
+              <environmentVariables>
+                <KEYCLOAK_VERSION>${keycloak.version}</KEYCLOAK_VERSION>
+              </environmentVariables>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Use Keycloak version specified in the `pom.xml` lso in the `docker-compose.yaml`. This allows Dependabot to automatically update the Keycloak version used in the integration test suite.






