### PR TITLE
Test improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ To run unit tests, use:
 ./mvnw clean test
 ```
 
+The coverage report is generated in `target/site/jacoco/index.html`.
+
 Integration tests require Docker Compose to start Keycloak and Envoy.
 Ensure Docker is installed.
 To run integration tests, use:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,8 +49,8 @@ services:
           --log-level=INFO,io.github.nordix.keycloak.services.x509:debug
 
     environment:
-      - KEYCLOAK_ADMIN=admin
-      - KEYCLOAK_ADMIN_PASSWORD=admin
+      - KC_BOOTSTRAP_ADMIN_USERNAME=admin
+      - KC_BOOTSTRAP_ADMIN_PASSWORD=admin
       - KC_HOSTNAME=https://keycloak.127.0.0.1.nip.io:8443
       - KC_HTTP_ENABLED=true
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
     <maven.project-info-reports-plugin.version>3.8.0</maven.project-info-reports-plugin.version>
     <maven.failsafe.plugin.version>3.5.1</maven.failsafe.plugin.version>
     <maven.checkstyle.plugin.version>3.6.0</maven.checkstyle.plugin.version>
+    <maven.jacoco.plugin.version>0.8.12</maven.jacoco.plugin.version>
 
   </properties>
 
@@ -186,6 +187,27 @@
                 <EXTENSION_JAR_PATH>${project.build.directory}/${project.artifactId}-${project.version}.jar</EXTENSION_JAR_PATH>
               </environmentVariables>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Jacoco coverage report -->
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${maven.jacoco.plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/src/test/java/io/github/nordix/keycloak/services/x509/ClientCertificateLookupIT.java
+++ b/src/test/java/io/github/nordix/keycloak/services/x509/ClientCertificateLookupIT.java
@@ -118,7 +118,7 @@ public class ClientCertificateLookupIT {
                 if (response.getStatusInfo().getFamily() != Response.Status.Family.SERVER_ERROR) {
                     break;
                 }
-                logger.infov("Response={0}", response.getStatus());
+                logger.infov("Response={0} {1}", response.getStatus(), response.getStatusInfo().getReasonPhrase());
 
             } catch (Exception e) {
                 logger.infov("Cannot connect: {0}", e.getMessage());
@@ -150,11 +150,13 @@ public class ClientCertificateLookupIT {
 
         Response response = target.request().post(Entity.form(form));
         String responseBody = response.readEntity(String.class);
-        Assertions.assertEquals(200, response.getStatus(), "Failed to fetch token. Response=" + responseBody);
+        Assertions.assertEquals(Response.Status.OK, response.getStatusInfo(),
+                "Was expecting 200 OK. Response=" + responseBody);
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode obj = mapper.readTree(responseBody);
-        Assertions.assertTrue(obj.has("access_token"), "Response does not contain access_token");
+        Assertions.assertTrue(obj.has("access_token"),
+                "Was expecting access_token in response but got: " + responseBody);
     }
 
     /**
@@ -175,7 +177,8 @@ public class ClientCertificateLookupIT {
 
         Response response = target.request().post(Entity.form(form));
         String responseBody = response.readEntity(String.class);
-        Assertions.assertEquals(401, response.getStatus(), "Was expecting 401 Unauthorized. Response=" + responseBody);
+        Assertions.assertEquals(Response.Status.UNAUTHORIZED, response.getStatusInfo(),
+                "Was expecting 401 Unauthorized. Response=" + responseBody);
     }
 
     /**
@@ -193,7 +196,8 @@ public class ClientCertificateLookupIT {
 
         Response response = target.request().post(Entity.form(form));
         String responseBody = response.readEntity(String.class);
-        Assertions.assertEquals(401, response.getStatus(), "Was expecting 401 Unauthorized. Response=" + responseBody);
+        Assertions.assertEquals(Response.Status.UNAUTHORIZED, response.getStatusInfo(),
+                "Was expecting 401 Unauthorized. Response=" + responseBody);
     }
 
     /**
@@ -213,7 +217,8 @@ public class ClientCertificateLookupIT {
         Response response = target.request().header("x-forwarded-client-cert", Helpers.getXfccWithCert(xfccCred))
                 .post(Entity.form(form));
         String responseBody = response.readEntity(String.class);
-        Assertions.assertEquals(401, response.getStatus(), "Was expecting 401 Unauthorized. Response=" + responseBody);
+        Assertions.assertEquals(Response.Status.UNAUTHORIZED, response.getStatusInfo(),
+                "Was expecting 401 Unauthorized. Response=" + responseBody);
     }
 
     /**
@@ -235,7 +240,8 @@ public class ClientCertificateLookupIT {
                 .post(Entity.form(form));
 
         String responseBody = response.readEntity(String.class);
-        Assertions.assertEquals(401, response.getStatus(), "Was expecting 401 Unauthorized. Response=" + responseBody);
+        Assertions.assertEquals(Response.Status.UNAUTHORIZED, response.getStatusInfo(),
+                "Was expecting 401 Unauthorized. Response=" + responseBody);
     }
 
     /**
@@ -246,7 +252,7 @@ public class ClientCertificateLookupIT {
      * 5. Keycloak X509 Authenticator accepts request (CN=authorized-client) and returns the token.
      */
     @Test
-    void TestInternalClientHttpsAuthorized() throws Exception {
+    void testInternalClientHttpsAuthorized() throws Exception {
         Credential tlsCred = new Credential().subject("CN=authorized-client").issuer(clientCa);
 
         WebTarget target = newTargetWithClientAuth(
@@ -254,11 +260,13 @@ public class ClientCertificateLookupIT {
 
         Response response = target.request().post(Entity.form(form));
         String responseBody = response.readEntity(String.class);
-        Assertions.assertEquals(200, response.getStatus(), "Failed to fetch token. Response=" + responseBody);
+        Assertions.assertEquals(Response.Status.OK, response.getStatusInfo(),
+                "Was expecting 200 OK. Response=" + responseBody);
 
         ObjectMapper mapper = new ObjectMapper();
         JsonNode obj = mapper.readTree(responseBody);
-        Assertions.assertTrue(obj.has("access_token"), "Response does not contain access_token");
+        Assertions.assertTrue(obj.has("access_token"),
+                "Was expecting access_token in response but got: " + responseBody);
     }
 
     // Helper methods

--- a/src/test/java/io/github/nordix/keycloak/services/x509/DockerComposeExtension.java
+++ b/src/test/java/io/github/nordix/keycloak/services/x509/DockerComposeExtension.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public class DockerComposeExtension implements BeforeAllCallback, AfterAllCallback {
 
     private static final String DOCKER_COMPOSE_UP = "docker compose up --force-recreate --no-color --abort-on-container-exit";
-    private static final String DOCKER_COMPOSE_DOWN = "docker compose down";
+    private static final String DOCKER_COMPOSE_DOWN = "docker compose rm --force --stop";
 
     private static Logger logger = Logger.getLogger(DockerComposeExtension.class);
 

--- a/src/test/java/io/github/nordix/keycloak/services/x509/Helpers.java
+++ b/src/test/java/io/github/nordix/keycloak/services/x509/Helpers.java
@@ -26,6 +26,9 @@ import fi.protonode.certy.Credential;
 
 public class Helpers {
 
+    /**
+     * Dummy password for the KeyStore for unit tests.
+     */
     static final String STORE_PASSWORD = "password";
 
     /**
@@ -38,24 +41,39 @@ public class Helpers {
         return factory.create(null);
     }
 
+    /**
+     * Get the certificate chain from the Credential in X509Certificate array.
+     */
     static X509Certificate[] getCertificateChain(Credential cred)
             throws CertificateException, NoSuchAlgorithmException {
         return Arrays.stream(cred.getCertificates()).map(cert -> (X509Certificate) cert)
                 .toArray(X509Certificate[]::new);
     }
 
+    /**
+     * Get XFCC element with the leaf certificate in "Cert" key.
+     * Hash is a dummy value.
+     */
     static String getXfccWithCert(Credential cred)
             throws CertificateException, NoSuchAlgorithmException, IOException {
         return String.format("Hash=1234;Cert=\"%s\"",
                 URLEncoder.encode(cred.getCertificateAsPem(), StandardCharsets.UTF_8));
     }
 
+    /**
+     * Get XFCC element with the certificate chain in "Chain" key.
+     * Hash is a dummy value.
+     */
     static String getXfccWithChain(Credential cred)
             throws CertificateException, NoSuchAlgorithmException, IOException {
         return String.format("Hash=1234;Chain=\"%s\"",
                 URLEncoder.encode(cred.getCertificatesAsPem(), StandardCharsets.UTF_8));
     }
 
+    /**
+     * Get XFCC element with both the leaf certificate in "Cert" and chain in "Chain" keys.
+     * Hash is a dummy value.
+     */
     static String getXfccWithCertAndChain(Credential cred)
             throws CertificateException, NoSuchAlgorithmException, IOException {
         return String.format("Hash=1234;Cert=\"%s\";Chain=\"%s\"",
@@ -63,6 +81,10 @@ public class Helpers {
                 URLEncoder.encode(cred.getCertificatesAsPem(), StandardCharsets.UTF_8));
     }
 
+    /**
+     * Create new KeyStore with the Credential.
+     * The password is set to {@link #STORE_PASSWORD}.
+     */
     static KeyStore newKeyStore(Credential cred)
             throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
         KeyStore ks = KeyStore.getInstance("PKCS12");
@@ -72,6 +94,9 @@ public class Helpers {
         return ks;
     }
 
+    /**
+     * Create new TrustStore with the Credential.
+     */
     static KeyStore newTrustStore(Credential cred)
             throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
         KeyStore ts = KeyStore.getInstance("PKCS12");

--- a/src/test/java/io/github/nordix/keycloak/services/x509/ScopeImpl.java
+++ b/src/test/java/io/github/nordix/keycloak/services/x509/ScopeImpl.java
@@ -15,7 +15,8 @@ import java.util.Map;
 import org.keycloak.Config.Scope;
 
 /**
- * Minimal implementation of Keycloak's Scope for unit testing purposes.
+ * Minimal implementation of Keycloak's Scope for unit tests.
+ * It is used to carry configuration parameters for the X509 client certificate lookup.
  */
 public class ScopeImpl implements Scope {
 

--- a/src/test/resources/integration-test/envoy-xfcc.yaml
+++ b/src/test/resources/integration-test/envoy-xfcc.yaml
@@ -1,5 +1,4 @@
 admin:
-  access_log_path: /dev/stdout
   address:
     socket_address:
       protocol: TCP
@@ -49,8 +48,7 @@ static_resources:
           access_log:
             - name: fileaccesslog
               typed_config:
-                "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-                path: /dev/stdout
+                "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
           http_filters:
           - name: envoy.filters.http.router
             typed_config:

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,3 +1,4 @@
+# Configuration file for the logging when running the tests.
 
 loggers=org.jboss.logging,io.github.nordix.keycloak.services.x509
 
@@ -15,6 +16,5 @@ handler.CONSOLE.autoFlush=true
 handler.CONSOLE.formatter=PATTERN
 
 formatter.PATTERN=org.jboss.logmanager.formatters.ColorPatternFormatter
-#formatter.PATTERN.pattern=%K{level}%d{HH:mm:ss,SSS} %-5p [%c{2.}] (%t) %s%e%n
 formatter.PATTERN.pattern=%d{HH:mm:ss} %-5p [%c{2.}] (%t) %s%e%n
 formatter.PATTERN.properties=pattern


### PR DESCRIPTION
* Fix occasional problem shutting down the containers when running `docker compose down` at the end of  integration tests.
* Added Jacoco for test coverage.
* Added new test cases to improve the coverage.
* Test code now uses symbolic HTTP status codes for clarity.
* Replaced some deprecated Envoy and Keycloak configuration in integration test.
