### PR TITLE
fix jboss log manager config file property name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,8 +140,8 @@
           <configuration>
             <systemPropertyVariables>
               <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-              <java.util.logging.config.file>
-                ${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+              <logging.configuration>
+                file:///${project.basedir}/src/test/resources/logging.properties</logging.configuration>
             </systemPropertyVariables>
           </configuration>
         </plugin>
@@ -179,8 +179,8 @@
             <configuration>
               <systemPropertyVariables>
                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                <java.util.logging.config.file>
-                  ${project.basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                <logging.configuration>
+                  file:///${project.basedir}/src/test/resources/logging.properties</logging.configuration>
               </systemPropertyVariables>
               <environmentVariables>
                 <KEYCLOAK_VERSION>${keycloak.version}</KEYCLOAK_VERSION>


### PR DESCRIPTION
The variable to set `logging.properties` for jboss logmanager was wrong in `pom.xml` though the logs have been working since logmanager has found the file from the resources directory automatically. This PR changes the variable name from `java.util.logging.config.file` (for `java.util.logging`) to `logging.configuration` (for jboss logmanager [link](https://github.com/jboss-logging/jboss-logmanager/blob/7ade35fda200f01cdade3b1990bd7299a7108ff3/src/main/java/org/jboss/logmanager/configuration/PropertyLogContextConfigurator.java#L98)) to correct variable also in `pom.xml` 
